### PR TITLE
Add a wrapper for contentSettings.ContentSetting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.*
 .idea
 test/.compiled
 test/.compiler*.txt
+.nrepl-port

--- a/src/lib/chromex/chrome_content_setting.cljs
+++ b/src/lib/chromex/chrome_content_setting.cljs
@@ -1,0 +1,39 @@
+(ns chromex.chrome-content-setting
+  (:refer-clojure :exclude [get set remove])
+  (:require [chromex.support :refer [get-hook]]
+            [oops.core :refer [ocall ocall!]]))
+
+(defprotocol IChromeContentSetting
+  "a wrapper for https://developer.chrome.com/extensions/contentSettings#type-ContentSetting"
+  (get-native-content-setting [this])
+  (get [this details])
+  (set [this details])
+  (clear [this details])
+  (get-resource-identifiers [this]))
+
+(deftype ChromeContentSetting [native-chrome-content-setting channel-factory callback-factory]
+  IChromeContentSetting
+  (get-native-content-setting [_this]
+    native-chrome-content-setting)
+  (get [_this details]
+    (let [channel (channel-factory)]
+      (ocall native-chrome-content-setting "get" details (callback-factory channel))
+      channel))
+  (set [_this details]
+    (let [channel (channel-factory)]
+      (ocall! native-chrome-content-setting "set" details (callback-factory channel))
+      channel))
+  (clear [_this details]
+    (let [channel (channel-factory)]
+      (ocall! native-chrome-content-setting "clear" details (callback-factory channel))
+      channel))
+  (get-resource-identifiers [_this]
+    (let [channel (channel-factory)]
+      (ocall native-chrome-content-setting "getResourceIdentifiers" (callback-factory channel))
+      channel)))
+
+(defn make-chrome-content-setting [config native-chrome-content-setting]
+  {:pre [native-chrome-content-setting]}
+  (ChromeContentSetting. native-chrome-content-setting
+                         (get-hook config :chrome-content-setting-callback-channel-factory)
+                         (get-hook config :chrome-content-setting-callback-fn-factory)))

--- a/src/lib/chromex/config.clj
+++ b/src/lib/chromex/config.clj
@@ -47,7 +47,9 @@
    :chrome-port-on-message-called-on-disconnected-port    'chromex.defaults/default-chrome-port-on-message-called-on-disconnected-port
    :chrome-port-post-message-called-with-nil              'chromex.defaults/default-chrome-port-post-message-called-with-nil
    :chrome-port-received-nil-message                      'chromex.defaults/default-chrome-port-received-nil-message
-   :chrome-port-put-message-called-on-disconnected-port   'chromex.defaults/default-chrome-port-put-message-called-on-disconnected-port})
+   :chrome-port-put-message-called-on-disconnected-port   'chromex.defaults/default-chrome-port-put-message-called-on-disconnected-port
+   :chrome-content-setting-callback-channel-factory       'chromex.defaults/default-chrome-content-setting-callback-channel-factory
+   :chrome-content-setting-callback-fn-factory            'chromex.defaults/default-chrome-content-setting-callback-fn-factory})
 
 
 ; config has to be generated via a macro:

--- a/src/lib/chromex/defaults.cljs
+++ b/src/lib/chromex/defaults.cljs
@@ -68,6 +68,16 @@
                            "Your Chrome version might be too old or too recent for running this extension.\n"
                            "This is a failure which probably requires a software update.")))))
 
+; -- ChromeContentSetting ------------------------------------------------------------------------------------------------------
+
+(defn default-chrome-content-setting-callback-fn-factory [config chan]
+  (fn [& args]
+    (let [last-error (oget (:root config) "chrome" "runtime" "?lastError")]
+      (put! chan [(vec args) last-error]))))
+
+(defn default-chrome-content-setting-callback-channel-factory [_config]
+  (chan))
+
 ; -- ChromeStorageArea ------------------------------------------------------------------------------------------------------
 
 (defn default-chrome-storage-area-callback-fn-factory [config chan]

--- a/src/lib/chromex/marshalling.clj
+++ b/src/lib/chromex/marshalling.clj
@@ -4,12 +4,14 @@
   (case type
     "runtime.Port" `(chromex.marshalling/to-native-chrome-port ~config ~param)
     "storage.StorageArea" `(chromex.marshalling/to-native-chrome-storage-area ~config ~param)
+    "contentSettings.ContentSetting" `(chromex.marshalling/to-native-chrome-content-setting ~config ~param)
     param))
 
 (defn marshall-from-chrome [config _id type param]
   (case type
     "runtime.Port" `(chromex.marshalling/from-native-chrome-port ~config ~param)
     "storage.StorageArea" `(chromex.marshalling/from-native-chrome-storage-area ~config ~param)
+    "contentSettings.ContentSetting" `(chromex.marshalling/from-native-chrome-content-setting ~config ~param)
     param))
 
 (defn gen-marshalling [config direction id type param]

--- a/src/lib/chromex/marshalling.cljs
+++ b/src/lib/chromex/marshalling.cljs
@@ -3,7 +3,8 @@
   (:require [chromex.protocols :as protocols]
             [chromex.config :refer [get-active-config]]
             [chromex.chrome-port :refer [make-chrome-port]]
-            [chromex.chrome-storage-area :refer [make-chrome-storage-area]]))
+            [chromex.chrome-storage-area :refer [make-chrome-storage-area]]
+            [chromex.chrome-content-setting :as cs]))
 
 (defn from-native-chrome-port [config native-chrome-port]
   (when (some? native-chrome-port)
@@ -22,3 +23,12 @@
   (when (some? chrome-storage-area)
     (satisfies? protocols/IChromeStorageArea chrome-storage-area)
     (protocols/get-native-storage-area chrome-storage-area)))
+
+(defn from-native-chrome-content-setting [config native-chrome-content-setting]
+  (when (some? native-chrome-content-setting)
+    (cs/make-chrome-content-setting config native-chrome-content-setting)))
+
+(defn to-native-chrome-content-setting [_config chrome-content-setting]
+  (when (some? chrome-content-setting)
+    (satisfies? cs/IChromeContentSetting chrome-content-setting)
+    (cs/get-native-content-setting chrome-content-setting)))

--- a/test/chromex/playground.clj
+++ b/test/chromex/playground.clj
@@ -41,6 +41,9 @@
 (defmacro get-port []
   (gen-call :function ::get-port &form))
 
+(defmacro get-content-setting []
+  (gen-call :function ::get-content-setting &form))
+
 (defmacro call-future-api []
   (gen-call :function ::call-future-api &form))
 
@@ -132,6 +135,10 @@
                {:id          ::get-port
                 :name        "getPort"
                 :return-type "runtime.Port"
+                :params      []}
+               {:id          ::get-content-setting
+                :name        "getContentSetting"
+                :return-type "contentSettings.ContentSetting"
                 :params      []}
                {:id     ::call-future-api
                 :name   "callFutureApi"

--- a/test/chromex/playground.cljs
+++ b/test/chromex/playground.cljs
@@ -34,6 +34,9 @@
 (defn get-port* [config]
   (gen-wrap :function ::get-port config))
 
+(defn get-content-setting* [config]
+  (gen-wrap :function ::get-content-setting config))
+
 (defn call-future-api* [config]
   (gen-wrap :function ::call-future-api config))
 

--- a/test/chromex/playground_mocks.cljs
+++ b/test/chromex/playground_mocks.cljs
@@ -82,6 +82,24 @@
     "clear" (fn [callback]
               (call-callback-with-delay callback "some 'clear' answer"))))
 
+(defn get-content-setting-mock []
+  (js-obj
+   "get" (fn [details callback]
+           (case (oget details "primaryPattern")
+             "https://www.google.com/*" (call-callback-with-delay callback "blocked")
+             nil (call-error-callback-with-delay callback "no primaryPattern")
+             (call-callback-with-delay callback "allowed")))
+   "set" (fn [details callback]
+           (case (oget details "primaryPattern")
+             nil (call-error-callback-with-delay callback "no primaryPattern")
+             (call-callback-with-delay callback)))
+   "clear" (fn [details callback]
+             (case details
+               nil (call-error-callback-with-delay callback "no details")
+               (call-callback-with-delay callback)))
+   "getResourceIdentifiers" (fn [callback]
+                              (call-callback-with-delay callback "some 'getResourceIdentifiers' answer"))))
+
 (defn make-event-object-mock []
   (let [state (atom {:listeners []})]
     (js-obj
@@ -128,6 +146,7 @@
 (oset! js/window ["chrome" "playground" "!onSomethingElse"] on-something-else-mock)
 (oset! js/window ["chrome" "playground" "!getStorageArea"] get-storage-area-mock)
 (oset! js/window ["chrome" "playground" "!getPort"] get-port-mock)
+(oset! js/window ["chrome" "playground" "!getContentSetting"] get-content-setting-mock)
 (oset! js/window ["chrome" "playground" "!callFutureApi"] (constantly nil))
 (oset! js/window ["chrome" "playground" "!callMasterApi"] (constantly nil))
 

--- a/test/chromex/runner.cljs
+++ b/test/chromex/runner.cljs
@@ -6,6 +6,7 @@
             [chromex.test-utils]
             [chromex.playground]
             [chromex.test.playground]
+            [chromex.test.chrome-content-setting]
             [chromex.test.chrome-storage-area]
             [chromex.test.chrome-port]
             [goog.object :as gobj]))
@@ -37,4 +38,5 @@
   (cljs.test/empty-env ::test/default)
   'chromex.test.playground
   'chromex.test.chrome-storage-area
-  'chromex.test.chrome-port)
+  'chromex.test.chrome-port
+  'chromex.test.chrome-content-setting)

--- a/test/chromex/test/chrome_content_setting.cljs
+++ b/test/chromex/test/chrome_content_setting.cljs
@@ -1,0 +1,23 @@
+(ns chromex.test.chrome-content-setting
+  (:require-macros [cljs.core.async.macros :refer [go]])
+  (:require [cljs.test :refer-macros [deftest testing is async]]
+            [cljs.core.async :refer [<!]]
+            [chromex.chrome-content-setting :as protocols :refer [IChromeContentSetting]]
+            [chromex.playground :refer-macros [get-content-setting]]))
+
+(deftest test-content-setting
+  (testing "excercise ChromeContentSetting"
+    (async done
+           (let [content-setting (get-content-setting)]
+             (go
+               (is (= (satisfies? IChromeContentSetting content-setting)))
+               (is (= [["blocked"] nil] (<! (protocols/get content-setting
+                                                           #js {"primaryPattern" "https://www.google.com/*"}))))
+               (is (= [["allowed"] nil] (<! (protocols/get content-setting
+                                                           #js {"primaryPattern" "foobar"}))))
+               (is (= [["some 'getResourceIdentifiers' answer"] nil]
+                      (<! (protocols/get-resource-identifiers content-setting))))
+               (is (= [[] nil] (<! (protocols/set content-setting #js {"primaryPattern" "foobar"}))))
+               (is (= [[] nil] (<! (protocols/clear content-setting #js {}))))
+               (is (= [[] "no details"] (<! (protocols/clear content-setting))))
+               (done))))))


### PR DESCRIPTION
This is a type with methods that take callbacks so we add marshaling that
converts them to async channels.

Closes #14.

Tests pass, ~but I ought to do some manual testing too~ and I manually tested with an extension I'm working on.